### PR TITLE
Handling of EmailReference messages

### DIFF
--- a/Src/Qaiain.CommandLine/App.config
+++ b/Src/Qaiain.CommandLine/App.config
@@ -3,7 +3,7 @@
   <appSettings>
     <add key="storageConnectionString" value="" />
     <add key="queue-name" value="qaiain"/>
-    <add key="blob-name" value="qaiain"/>
+    <add key="messages-container" value="qaiain"/>
     <!--Email settings-->
     <add key="email-host" value="" />
     <add key="email-port" value="" />

--- a/Src/Qaiain.CommandLine/App.config
+++ b/Src/Qaiain.CommandLine/App.config
@@ -3,7 +3,7 @@
   <appSettings>
     <add key="storageConnectionString" value="" />
     <add key="queue-name" value="qaiain"/>
-    <add key="messages-container" value="qaiain"/>
+    <add key="messages-container" value="messages"/>
     <!--Email settings-->
     <add key="email-host" value="" />
     <add key="email-port" value="" />

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -168,6 +168,7 @@ let handle (getMessage) (deleteMessage) (sendEmail) msg =
     match msg |> Mail.parse with
     | Mail.EmailData mail ->
         mail |> sendEmail
+    | _ -> raise <| InvalidOperationException("Unknown message type.")
 
 let rec private _handle msg =
     match msg |> Mail.parse with

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -164,10 +164,15 @@ let send =
 
     Mail.send config
 
-let handle (getMessage) (deleteMessage) (sendEmail) msg =
+let rec handle (getMessage) (deleteMessage) (sendEmail) msg =
     match msg |> Mail.parse with
     | Mail.EmailData mail ->
         mail |> sendEmail
+    | Mail.EmailReference ref ->
+        match ref.DataAddress |> getMessage with
+        | Some message ->
+            message |> handle getMessage deleteMessage sendEmail
+        | None -> ()
     | _ -> raise <| InvalidOperationException("Unknown message type.")
 
 let rec private _handle msg =

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -164,13 +164,13 @@ let send =
 
     Mail.send config
 
-let rec handle msg =
+let rec private _handle msg =
     match msg |> Mail.parse with
     | Mail.EmailData mail ->
         send mail
     | Mail.EmailReference ref ->
         let b = blob.GetBlockBlobReference(ref.DataAddress)
-        b.DownloadText() |> handle
+        b.DownloadText() |> _handle
         b.Delete()
     | _ -> raise <| InvalidOperationException("Unknown message type.")
 
@@ -178,7 +178,7 @@ let rec handle msg =
 let main argv = 
     match queue |> AzureQ.dequeue with
     | Some(msg) ->
-        handle msg.AsString
+        _handle msg.AsString
         queue.DeleteMessage msg
     | _ -> ()
 

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -172,6 +172,7 @@ let rec handle (getMessage) (deleteMessage) (sendEmail) msg =
         match ref.DataAddress |> getMessage with
         | Some message ->
             message |> handle getMessage deleteMessage sendEmail
+            ref.DataAddress |> deleteMessage
         | None -> ()
     | _ -> raise <| InvalidOperationException("Unknown message type.")
 

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -164,6 +164,11 @@ let send =
 
     Mail.send config
 
+let handle (getMessage) (deleteMessage) (sendEmail) msg =
+    match msg |> Mail.parse with
+    | Mail.EmailData mail ->
+        mail |> sendEmail
+
 let rec private _handle msg =
     match msg |> Mail.parse with
     | Mail.EmailData mail ->

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -140,7 +140,7 @@ let queue =
     q.CreateIfNotExists() |> ignore
     q
 
-let blob =
+let private blob =
     let storageAccount =
         CloudConfigurationManager.GetSetting "storageConnectionString"
         |> CloudStorageAccount.Parse

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -145,7 +145,7 @@ let blob =
         CloudConfigurationManager.GetSetting "storageConnectionString"
         |> CloudStorageAccount.Parse
 
-    let name = CloudConfigurationManager.GetSetting "blob-name"
+    let name = CloudConfigurationManager.GetSetting "messages-container"
     let blob = storageAccount.CreateCloudBlobClient().GetContainerReference(name)
     blob.CreateIfNotExists() |> ignore
     blob

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -406,3 +406,45 @@ let HandleSendsCorrectEmailForPointerMessages () =
     |> handle
 
     verify <@ verified = ref true @>
+
+[<Fact>]
+let HandleDeletesCorrectMessageForPointerMessages () =
+    let verified = ref false
+    let expected = "http://blobs.foo.bar/baz/qux"
+    let deleteMessage actual =
+        verified := expected = actual
+        ()
+    let getMessage dummyArg =
+        """<?xml version="1.0"?>
+           <email xmlns="urn:grean:schemas:email:2014">
+             <from>
+               <smtp-address>foo@foo.com</smtp-address>
+               <display-name>Foo</display-name>
+             </from>
+             <to>
+               <address>
+                 <display-name>Bar</display-name>
+                 <smtp-address>bar@bar.com</smtp-address>
+               </address>
+             </to>
+             <subject>Test</subject>
+             <body>This is a test message.</body>
+             <attachments>
+               <attachment>
+                 <content>MQ==</content>
+                 <mime-type>image/png</mime-type>
+                 <name>Quux</name>
+               </attachment>
+             </attachments>
+           </email>"""
+        |> Some
+    let handle message =
+        handle getMessage deleteMessage (fun x -> ()) message
+
+    """<?xml version="1.0"?>
+       <email-reference xmlns:e="urn:grean:schemas:email:2014">
+         <e:data-address>""" + expected + """</e:data-address>
+       </email-reference>"""
+    |> handle
+
+    verify <@ verified = ref true @>

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -414,7 +414,7 @@ let HandleDeletesCorrectMessageForPointerMessages () =
     let deleteMessage actual =
         verified := expected = actual
         ()
-    let getMessage dummyArg =
+    let getMessage _ =
         """<?xml version="1.0"?>
            <email xmlns="urn:grean:schemas:email:2014">
              <from>
@@ -448,3 +448,20 @@ let HandleDeletesCorrectMessageForPointerMessages () =
     |> handle
 
     verify <@ verified = ref true @>
+
+[<Fact>]
+let HandleDoesNotDeletesNonExistingBlobs () =
+    let verified = ref false
+    let deleteMessage _ =
+        verified := true
+        ()
+    let handle message =
+        handle (fun x -> None) deleteMessage (fun x -> ()) message
+
+    """<?xml version="1.0"?>
+       <email-reference xmlns:e="urn:grean:schemas:email:2014">
+         <e:data-address>http://non.existing.blob/ni/kos</e:data-address>
+       </email-reference>"""
+    |> handle
+
+    verify <@ verified = ref false @>

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -309,6 +309,8 @@ let ParseReturnsCorrectResult () =
         verify <@ tc.expected = actual @>))
 
 open Program
+open System
+open Swensen.Unquote.Assertions
 
 [<Fact>]
 let HandleSendsCorrectEmail () =
@@ -344,3 +346,10 @@ let HandleSendsCorrectEmail () =
     |> handle
 
     verify <@ verified = ref true @>
+
+[<Fact>]
+let HandleThrowsForUnknownMessage () =
+    let handle message =
+        handle (fun x -> "" |> Some) (fun x -> ()) (fun x -> ()) message
+
+    raises<InvalidOperationException> <@ "<bar" |> handle @>


### PR DESCRIPTION
This pull request handles the EmailReference pointer message (related to #4) as discussed in #18.

It has been tested with:
- [Mailtrap.io](https://mailtrap.io/)<sup>*</sup> for attachments of small size ~1MB
- the technique I previously described [here](https://github.com/GreanTech/Qaiain/pull/18/files#r14179272) for attachments of size ~20MB

---

<sup>*</sup>Mailtrap.io rocks!, by the way. :) 
