### PR TITLE
A more precise return type for the handle function

### DIFF
--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -144,7 +144,7 @@ module Mail =
                 message |> handle getMessage deleteMessage sendEmail |> ignore
                 ref.DataAddress |> deleteMessage |> Success
             | None -> () |> Success
-        | _ -> Failure <| InvalidOperationException("Unknown message type.")
+        | _ -> "Unknown message type." |> Failure
 
 let queue =
     let storageAccount =
@@ -196,7 +196,7 @@ let main argv =
     | Some(msg) ->
         match msg.AsString |> handle with
         | Success _ -> queue.DeleteMessage msg
-        | Failure e -> raise e
+        | Failure f -> raise <| InvalidOperationException(f)
     | _ -> ()
 
     0 // return an integer exit code

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -3,7 +3,7 @@ open System.IO
 open Microsoft.WindowsAzure
 open Microsoft.WindowsAzure.Storage
 
-type Either<'TSuccess, 'TFailure> =
+type Result<'TSuccess, 'TFailure> =
     | Success of 'TSuccess
     | Failure of 'TFailure
 

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -7,9 +7,6 @@ type Result<'TSuccess, 'TFailure> =
     | Success of 'TSuccess
     | Failure of 'TFailure
 
-type ErrorMessage =
-    | UnknownMessageType
-
 module AzureQ =
     let dequeue (q : Queue.CloudQueue) =
         match q.GetMessage() with
@@ -44,6 +41,9 @@ module Mail =
         | EmailData of EmailData
         | EmailReference of EmailReference
         | Unknown
+
+    type ErrorMessage =
+        | UnknownMessageType
 
     open System.Xml
 

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -199,11 +199,14 @@ let main argv =
 
     let handle msg = Mail.handle getMessage deleteMessage send msg
 
+    let exitCode = ref 0
     match queue |> AzureQ.dequeue with
     | Some(msg) ->
         match msg.AsString |> handle with
         | Success _ -> queue.DeleteMessage msg
-        | Failure f -> f |> toString |> Console.Error.WriteLine
+        | Failure f ->
+            f |> toString |> Console.Error.WriteLine
+            exitCode := 13
     | _ -> ()
 
-    0 // return an integer exit code
+    !exitCode // return an integer exit code

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -199,14 +199,13 @@ let main argv =
 
     let handle msg = Mail.handle getMessage deleteMessage send msg
 
-    let exitCode = ref 0
     match queue |> AzureQ.dequeue with
     | Some(msg) ->
         match msg.AsString |> handle with
-        | Success _ -> queue.DeleteMessage msg
+        | Success _ ->
+            queue.DeleteMessage msg
+            0
         | Failure f ->
             f |> toString |> Console.Error.WriteLine
-            exitCode := 13
-    | _ -> ()
-
-    !exitCode // return an integer exit code
+            13
+    | _ -> 0

--- a/Src/Qaiain.CommandLine/Program.fs
+++ b/Src/Qaiain.CommandLine/Program.fs
@@ -193,10 +193,9 @@ let main argv =
         try blob.GetBlockBlobReference(blobName).Delete()
         with | :? StorageException -> ()
 
-    let toException errorMessage =
+    let toString errorMessage =
         match errorMessage with
-        | UnknownMessageType ->
-            InvalidOperationException("Unknown message type.")
+        | Mail.ErrorMessage.UnknownMessageType -> "Unknown message type."
 
     let handle msg = Mail.handle getMessage deleteMessage send msg
 
@@ -204,7 +203,7 @@ let main argv =
     | Some(msg) ->
         match msg.AsString |> handle with
         | Success _ -> queue.DeleteMessage msg
-        | Failure f -> f |> toException |> raise
+        | Failure f -> f |> toString |> Console.Error.WriteLine
     | _ -> ()
 
     0 // return an integer exit code

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -350,7 +350,7 @@ let HandleSendsCorrectEmail () =
 [<Fact>]
 let HandleReturnsCorrectResultForUnknownMessage () =
     let verified = ref false
-    let expected = "Unknown message type."
+    let expected = UnknownMessageType
     let handle message =
         handle (fun x -> "" |> Some) ignore ignore message
 

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -308,6 +308,7 @@ let ParseReturnsCorrectResult () =
         let actual = parse tc.input
         verify <@ tc.expected = actual @>))
 
+open Program
 open System
 open Swensen.Unquote.Assertions
 
@@ -347,11 +348,17 @@ let HandleSendsCorrectEmail () =
     verify <@ verified = ref true @>
 
 [<Fact>]
-let HandleThrowsForUnknownMessage () =
+let HandleReturnsCorrectResultForUnknownMessage () =
+    let verified = ref false
     let handle message =
         handle (fun x -> "" |> Some) ignore ignore message
 
-    raises<InvalidOperationException> <@ "<bar" |> handle @>
+    let actual =
+        match "<bar" |> handle with
+        | Failure e -> verified := e.GetType() = typeof<InvalidOperationException>
+        | Success _ -> verified := false
+
+    verify <@ verified = ref true @>
 
 [<Fact>]
 let HandleSendsCorrectEmailForPointerMessages () =

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -326,7 +326,7 @@ let HandleSendsCorrectEmail () =
         verified := expected = actual
         ()
     let handle message =
-        handle (fun x -> "" |> Some) ignore sendEmail message
+        handle (fun x -> "" |> Some) ignore sendEmail message |> ignore
 
     """<?xml version="1.0"?>
        <email xmlns:e="urn:grean:schemas:email:2014">
@@ -409,7 +409,7 @@ let HandleSendsCorrectEmailForPointerMessages () =
        <email-reference xmlns:e="urn:grean:schemas:email:2014">
          <e:data-address>""" + dataAddress + """</e:data-address>
        </email-reference>"""
-    |> handle
+    |> handle |> ignore
 
     verify <@ verified = ref true @>
 
@@ -451,7 +451,7 @@ let HandleDeletesCorrectMessageForPointerMessages () =
        <email-reference xmlns:e="urn:grean:schemas:email:2014">
          <e:data-address>""" + expected + """</e:data-address>
        </email-reference>"""
-    |> handle
+    |> handle |> ignore
 
     verify <@ verified = ref true @>
 
@@ -468,6 +468,6 @@ let HandleDoesNotDeletesNonExistingBlobs () =
        <email-reference xmlns:e="urn:grean:schemas:email:2014">
          <e:data-address>http://non.existing.blob/ni/kos</e:data-address>
        </email-reference>"""
-    |> handle
+    |> handle |> ignore
 
     verify <@ verified = ref false @>

--- a/Src/Qaiain.UnitTests/MailTests.fs
+++ b/Src/Qaiain.UnitTests/MailTests.fs
@@ -350,12 +350,13 @@ let HandleSendsCorrectEmail () =
 [<Fact>]
 let HandleReturnsCorrectResultForUnknownMessage () =
     let verified = ref false
+    let expected = "Unknown message type."
     let handle message =
         handle (fun x -> "" |> Some) ignore ignore message
 
     let actual =
         match "<bar" |> handle with
-        | Failure e -> verified := e.GetType() = typeof<InvalidOperationException>
+        | Failure actual -> verified := expected = actual
         | Success _ -> verified := false
 
     verify <@ verified = ref true @>


### PR DESCRIPTION
Although the `handle` function in the `Mail` module returns `Unit` it can also throw exception in the case of an unknown message type.

We should change the return type from `Unit` to something that includes the case of failure, something like:
- [Try](http://www.scala-lang.org/files/archive/nightly/docs/library/index.html#scala.util.Try) in Scala
- [Either](https://hackage.haskell.org/package/base-4.7.0.1/docs/Data-Either.html) in Haskell
- [Choice](http://msdn.microsoft.com/en-us/library/ee353439.aspx) in F# - although in my opinion it's extremely undescriptive

This Pull Request changes the `handle` function in the `Mail` module to return:

```
Either<unit, InvalidOperationException>
```

If we take this direction, we can probably use the introduced `Either` type as the monadic value in #6.
